### PR TITLE
[ch81484] Remove word mobile when refering to key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### LaunchDarkly Sample C Server-Side Application ###
 We've built a simple console application that demonstrates how LaunchDarkly's SDK works. Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/).
 ##### Build instructions #####
-1. Copy your Mobile SDK key and feature flag key from your LaunchDarkly dashboard into `hello.c`
+1. Copy your SDK key and feature flag key from your LaunchDarkly dashboard into `hello.c`
 2. Run `make`
 3. Run `./hello`


### PR DESCRIPTION
CI is failing but only because CircleCI is enabled, but with no config on this branch.