### PR TITLE
Update build-mac.sh to force cross-compilation on Apple Silicon

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,1 +1,1 @@
-clang -o hello hello.c lib/libldserverapi.a -I include -lcurl -lpthread -lpcre -lm -framework CoreFoundation -framework IOKit
+clang -target x86_64-apple-darwin21.1.0 -o hello hello.c lib/libldserverapi.a -I include -lcurl -lpthread -lpcre -lm -framework CoreFoundation -framework IOKit


### PR DESCRIPTION
Updates `build-mac.sh` to compile the `hello` binary for x86_64.

Currently, the build will fail on M1 because we're trying to link with the existing x86_64 `ldserverapi` library.

See also: [hello-c-client](https://github.com/launchdarkly/hello-c-client/pull/10).