### PR TITLE
Update xcode image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
 
   build-test-osx:
     macos:
-      xcode: "12.4.0"
+      xcode: "12.5.1"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
According to the CircleCI announcement on [June 2nd, 2022][1], several
xcode images are going to be deprecated and removed. This commit bumps
our xcode versions to a supported image version.

[1]: https://discuss.circleci.com/t/xcode-image-deprecation/44294